### PR TITLE
Probe hash table from quiescence search

### DIFF
--- a/src/main/java/dev/jamesswafford/chess4j/search/AlphaBetaSearch.java
+++ b/src/main/java/dev/jamesswafford/chess4j/search/AlphaBetaSearch.java
@@ -351,6 +351,29 @@ public class AlphaBetaSearch implements Search {
 
         searchStats.qnodes++;
 
+        // probe the hash table.  Any entry found is at least as deep as the search we'd otherwise do here, since
+        // quiescence search is effectively depth 0.  We only read from the table -- an entry is never stored from
+        // qsearch, since we don't do a full-width move search here.
+        TranspositionTableEntry tte = TTHolder.getInstance().getHashTable().probe(board);
+        if (tte != null) {
+            if (tte.getType() == LOWER_BOUND) {
+                if (tte.getScore() >= beta) {
+                    searchStats.failHighs++;
+                    searchStats.hashFailHighs++;
+                    return tte.getScore();
+                }
+            } else if (tte.getType() == UPPER_BOUND) {
+                if (tte.getScore() <= alpha) {
+                    searchStats.failLows++;
+                    searchStats.hashFailLows++;
+                    return tte.getScore();
+                }
+            } else if (tte.getType() == EXACT_SCORE) {
+                searchStats.hashExactScores++;
+                return tte.getScore();
+            }
+        }
+
         int standPat = Globals.getNeuralNetwork().map(nn -> nn.eval(board))
                 .orElseGet(() -> evaluator.evaluateBoard(board));
         if (standPat > alpha) {


### PR DESCRIPTION
## Summary
- Quiescence search now probes the transposition table before searching and takes a fail-high/fail-low/exact-score cutoff using the same bound logic as the main search.
- Read-only: qsearch never calls `store()`, since it isn't a full-width move search and shouldn't populate the table.

## Test plan
- [x] `mvn test -Dtest=AlphaBetaSearchTest,PerfTest` passes (run locally by user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AnorDxseiN9jbCye8MnSr